### PR TITLE
Add info about using the Success Flash Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,17 @@ On your `contact/thanks.html` template, you can access that `from` parameter usi
 
 Note that if you don’t include a `redirect` input, the current page will get reloaded.
 
+### Displaying flash messages
 
-### Using the Success Flash Message
-
-You can access the value of the success flash message setting by calling `craft.app.session.getFlash('notice')` in your template:
+When a contact form is submitted, the plugin will set a `notice` or `success` flash message on the user session. You can display it in your template like this:
 
 ```twig
-<p>{{ craft.app.session.getFlash('notice') }}</p>
+{% if craft.app.session.hasFlash('notice') %}
+    <p class="message notice">{{ craft.app.session.getFlash('notice') }}</p>
+{% elseif craft.app.session.hasFlash('error') %}
+    <p class="message error">{{ craft.app.session.getFlash('error') }}</p>
+{% endif %}
 ```
-
 
 ### Adding additional fields
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ On your `contact/thanks.html` template, you can access that `from` parameter usi
 Note that if you don’t include a `redirect` input, the current page will get reloaded.
 
 
+### Using the Success Flash Message
+
+You can access the value of the success flash message setting by calling `craft.app.session.getFlash('notice')` in your template:
+
+```twig
+<p>{{ craft.app.session.getFlash('notice') }}</p>
+```
+
+
 ### Adding additional fields
 
 You can add additional fields to your form by splitting your `message` field into multiple fields, using an array syntax for the input names:


### PR DESCRIPTION
In Craft 3, flash notices aren't in the templates by default.

I noticed there is an issue about showing the success message, and I had trouble figuring it out myself, so I thought a small example would help a lot of people out using this seemingly useless setting.