### PR TITLE
Add message for ajax submit

### DIFF
--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -62,7 +62,10 @@ class SendController extends Controller
         }
 
         if ($request->getAcceptsJson()) {
-            return $this->asJson(['success' => true]);
+            return $this->asJson([
+                'success' => true,
+                'message' => $settings->successFlashMessage
+            ]);
         }
 
         Craft::$app->getSession()->setNotice($settings->successFlashMessage);


### PR DESCRIPTION
When performing an ajax submit I was having a hard time accessing the success message in settings. This update allows me to access the success message that would normally be accessed through the craft flash message while using ajax.