### PR TITLE
Corrected csrfInput() to getCsrfInput()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Your contact form template can look something like this:
 {% from _self import errorList %}
 
 <form method="post" action="" accept-charset="UTF-8">
-    {{ csrfInput() }}
+    {{ getCsrfInput() }}
     <input type="hidden" name="action" value="contact-form/send">
     <input type="hidden" name="redirect" value="{{ 'contact/thanks'|hash }}">
 


### PR DESCRIPTION
Craft 2.x gives an error when using `csrfInput()` - I assume this is supposed to be `getCsrfInput()`?