### PR TITLE
fixes attachment bug

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -70,6 +70,7 @@ class Mailer extends Component
 
         if ($submission->attachment !== null) {
             foreach ($submission->attachment as $attachment) {
+                if (!$attachment) continue;
                 $message->attach($attachment->tempName, [
                     'fileName' => $attachment->name,
                     'contentType' => FileHelper::getMimeType($attachment->tempName),

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -70,7 +70,9 @@ class Mailer extends Component
 
         if ($submission->attachment !== null) {
             foreach ($submission->attachment as $attachment) {
-                if (!$attachment) continue;
+                if (!$attachment) {
+                    continue;
+                }
                 $message->attach($attachment->tempName, [
                     'fileName' => $attachment->name,
                     'contentType' => FileHelper::getMimeType($attachment->tempName),


### PR DESCRIPTION
If an optional file attachment is empty, Mailer.php will cause an error because it only checks if $submission->attachment is null (which it never is, because it is always an array if the form contains a file attachment field).

p.s.: this is my very very first pull request, please don't blame me :-)