### PR TITLE
Fixes #126 Name field rendering in template

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -188,6 +188,11 @@ class Mailer extends Component
         $text = '';
 
         foreach ($fields as $key => $value) {
+            // Skip displaying Name field if fromName is blank
+            if ($key == 'Name' and $value == '') {
+                continue;
+            }
+
             $text .= ($text ? "\n" : '')."- **{$key}:** ";
             if (is_array($value)) {
                 $text .= implode(', ', $value);


### PR DESCRIPTION
fromName is not a required field, so if it is left blank, we don’t need to display it in the email.