### PR TITLE
New message from {systemName}

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -48,8 +48,8 @@ class Settings extends Model
         }
 
         if ($this->prependSubject === null) {
-            $this->prependSubject = \Craft::t('contact-form', 'New message from {siteName}', [
-                'siteName' => \Craft::$app->getSites()->getCurrentSite()->name
+            $this->prependSubject = \Craft::t('contact-form', 'New message from {systemName}', [
+                'systemName' => \Craft::$app->getInfo()->name
             ]);
         }
 


### PR DESCRIPTION
Nicer default email subject when site names are named after locales and the subject reads “New message from English“.