### PR TITLE
change how multiple recipients are emailed

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -97,10 +97,8 @@ class Mailer extends Component
             return true;
         }
 
-        foreach ($event->toEmails as $toEmail) {
-            $message->setTo($toEmail);
-            $mailer->send($message);
-        }
+        $message->setTo($event->toEmails);
+        $mailer->send($message);
 
         // Fire an 'afterSend' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_SEND)) {


### PR DESCRIPTION
Looping over a list of email addresses and sending each one individually can cause throttling issues with services like mailtrap and AWS SES. mailtrap has a 2 send per second and SES, by default, is 1 per second. Since the mailer accepts an array for the setTo, I tested this and it works.