### PR TITLE
Ability to override submission model for more customizable forms

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -57,9 +57,9 @@ class Mailer extends Component
 
         // Prep the message
         $fromEmail = $this->getFromEmail($mailer->from);
-        $fromName = $this->compileFromName($submission->fromName);
-        $subject = $this->compileSubject($submission->subject);
-        $textBody = $this->compileTextBody($submission);
+        $fromName = $submission->compileFromName();
+        $subject = $submission->compileSubject();
+        $textBody = $submission->compileTextBody();
         $htmlBody = $this->compileHtmlBody($textBody);
 
         $message = (new Message())
@@ -138,73 +138,6 @@ class Mailer extends Component
             return $key;
         }
         throw new InvalidConfigException('Can\'t determine "From" email from email config settings.');
-    }
-
-    /**
-     * Compiles the "From" name value from the submitted name.
-     *
-     * @param string|null $fromName
-     * @return string
-     */
-    public function compileFromName(string $fromName = null): string
-    {
-        $settings = Plugin::getInstance()->getSettings();
-        return $settings->prependSender.($settings->prependSender && $fromName ? ' ' : '').$fromName;
-    }
-
-    /**
-     * Compiles the real email subject from the submitted subject.
-     *
-     * @param string|null $subject
-     * @return string
-     */
-    public function compileSubject(string $subject = null): string
-    {
-        $settings = Plugin::getInstance()->getSettings();
-        return $settings->prependSubject.($settings->prependSubject && $subject ? ' - ' : '').$subject;
-    }
-
-    /**
-     * Compiles the real email textual body from the submitted message.
-     *
-     * @param Submission $submission
-     * @return string
-     */
-    public function compileTextBody(Submission $submission): string
-    {
-        $fields = [];
-
-        if ($submission->fromName) {
-            $fields[Craft::t('contact-form', 'Name')] = $submission->fromName;
-        }
-
-        $fields[Craft::t('contact-form', 'Email')] = $submission->fromEmail;
-
-        if (is_array($submission->message)) {
-            $body = $submission->message['body'] ?? '';
-            $fields = array_merge($fields, $submission->message);
-            unset($fields['body']);
-        } else {
-            $body = (string)$submission->message;
-        }
-
-        $text = '';
-
-        foreach ($fields as $key => $value) {
-            $text .= ($text ? "\n" : '')."- **{$key}:** ";
-            if (is_array($value)) {
-                $text .= implode(', ', $value);
-            } else {
-                $text .= $value;
-            }
-        }
-
-        if ($body !== '') {
-            $body = preg_replace('/\R/', "\n\n", $body);
-            $text .= "\n\n".$body;
-        }
-
-        return $text;
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,7 @@
 namespace craft\contactform;
 
 use Craft;
+use craft\base\Plugin as BasePlugin;
 use craft\contactform\models\Settings;
 
 /**
@@ -17,7 +18,7 @@ use craft\contactform\models\Settings;
  * @property Mailer $mailer
  * @method Settings getSettings()
  */
-class Plugin extends \craft\base\Plugin
+class Plugin extends BasePlugin
 {
     /**
      * @inheritdoc

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -4,6 +4,7 @@ namespace craft\contactform\controllers;
 
 use Craft;
 use craft\contactform\models\Submission;
+use craft\contactform\models\SubmissionInterface;
 use craft\contactform\Plugin;
 use craft\web\Controller;
 use craft\web\UploadedFile;
@@ -39,6 +40,11 @@ class SendController extends Controller
         }
 
         $submission = new $submissionModel();
+
+        if (!$submission instanceof SubmissionInterface) {
+            throw new \Exception("Submission class provided must implement the SubmissionInterface");
+        }
+
         $submission = $submission->populateModel($request);
 
         $message = $request->getBodyParam('message');

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -33,11 +33,13 @@ class SendController extends Controller
         $request = Craft::$app->getRequest();
         $plugin = Plugin::getInstance();
         $settings = $plugin->getSettings();
+        
+        if (class_exists($settings->submissionModel)) {
+            $submissionModel = $settings->submissionModel;
+        }
 
-        $submission = new Submission();
-        $submission->fromEmail = $request->getBodyParam('fromEmail');
-        $submission->fromName = $request->getBodyParam('fromName');
-        $submission->subject = $request->getBodyParam('subject');
+        $submission = new $submissionModel();
+        $submission = $submission->populateModel($request);
 
         $message = $request->getBodyParam('message');
         if (is_array($message)) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -37,6 +37,11 @@ class Settings extends Model
     public $successFlashMessage;
 
     /**
+     * @var string|null
+     */
+    public $submissionModel = "craft\\contactform\\models\\Submission";
+
+    /**
      * @inheritdoc
      */
     public function init()

--- a/src/models/Submission.php
+++ b/src/models/Submission.php
@@ -7,15 +7,18 @@
 
 namespace craft\contactform\models;
 
+use Craft;
 use craft\base\Model;
 use craft\web\UploadedFile;
+use craft\web\Request;
+use craft\contactform\Plugin;
 
 /**
  * Class Submission
  *
  * @package craft\contactform
  */
-class Submission extends Model
+class Submission extends Model implements SubmissionInterface
 {
     /**
      * @var string|null
@@ -43,15 +46,92 @@ class Submission extends Model
     public $attachment;
 
     /**
+     * 
+     */
+    public function populateModel(Request $request): Submission
+    {
+        $this->fromEmail = $request->getBodyParam('fromEmail');
+        $this->fromName = $request->getBodyParam('fromName');
+        $this->subject = $request->getBodyParam('subject');
+
+        return $this;
+    }
+
+    /**
+     * Compiles the "From" name value from the submitted name.
+     *
+     * @return string
+     */
+    public function compileFromName(): string
+    {
+        $settings = Plugin::getInstance()->getSettings();
+        return $settings->prependSender.($settings->prependSender && $this->fromName ? ' ' : '').$this->fromName;
+    }
+
+    /**
+     * Compiles the real email subject from the submitted subject.
+     *
+     * @return string
+     */
+    public function compileSubject(): string
+    {
+        $settings = Plugin::getInstance()->getSettings();
+        return $settings->prependSubject.($settings->prependSubject && $this->subject ? ' - ' : '').$this->subject;
+    }
+
+    /**
+     * Compiles the real email textual body from the submitted message.
+     *
+     * @param Submission $submission
+     * @return string
+     */
+    public function compileTextBody(): string
+    {
+        $fields = [];
+
+        if ($this->fromName) {
+            $fields[Craft::t('contact-form', 'Name')] = $this->fromName;
+        }
+
+        $fields[Craft::t('contact-form', 'Email')] = $this->fromEmail;
+
+        if (is_array($this->message)) {
+            $body = $this->message['body'] ?? '';
+            $fields = array_merge($fields, $this->message);
+            unset($fields['body']);
+        } else {
+            $body = (string)$this->message;
+        }
+
+        $text = '';
+
+        foreach ($fields as $key => $value) {
+            $text .= ($text ? "\n" : '')."- **{$key}:** ";
+            if (is_array($value)) {
+                $text .= implode(', ', $value);
+            } else {
+                $text .= $value;
+            }
+        }
+
+        if ($body !== '') {
+            $body = preg_replace('/\R/', "\n\n", $body);
+            $text .= "\n\n".$body;
+        }
+
+        return $text;
+    }
+
+    /**
      * @inheritdoc
      */
     public function attributeLabels()
     {
         return [
-            'fromName' => \Craft::t('contact-form', 'Your Name'),
-            'fromEmail' => \Craft::t('contact-form', 'Your Email'),
-            'message' => \Craft::t('contact-form', 'Message'),
-            'subject' => \Craft::t('contact-form', 'Subject'),
+            'fromName' => Craft::t('contact-form', 'Your Name'),
+            'fromEmail' => Craft::t('contact-form', 'Your Email'),
+            'message' => Craft::t('contact-form', 'Message'),
+            'subject' => Craft::t('contact-form', 'Subject'),
         ];
     }
 

--- a/src/models/Submission.php
+++ b/src/models/Submission.php
@@ -48,7 +48,7 @@ class Submission extends Model implements SubmissionInterface
     /**
      * 
      */
-    public function populateModel(Request $request): Submission
+    public function populateModel(Request $request)
     {
         $this->fromEmail = $request->getBodyParam('fromEmail');
         $this->fromName = $request->getBodyParam('fromName');

--- a/src/models/SubmissionInterface.php
+++ b/src/models/SubmissionInterface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license MIT
+ */
+
+namespace craft\contactform\models;
+
+use Craft;
+use craft\base\Model;
+use craft\web\UploadedFile;
+use craft\web\Request;
+use craft\contactform\Plugin;
+
+/**
+ * Class Submission
+ *
+ * @package craft\contactform
+ */
+interface SubmissionInterface
+{
+    /**
+     * Populates the model with params from request
+     * 
+     * @return Submission model
+     */
+    public function populateModel(Request $request): Submission;
+
+    /**
+     * Compiles the "From" name value from the submitted name.
+     *
+     * @return string
+     */
+    public function compileFromName(): string;
+
+    /**
+     * Compiles the real email subject from the submitted subject.
+     *
+     * @return string
+     */
+    public function compileSubject(): string;
+
+    /**
+     * Compiles the real email textual body from the submitted message.
+     *
+     * @param Submission $submission
+     * @return string
+     */
+    public function compileTextBody(): string;
+
+    /**
+     * @inheritdoc
+     */
+    public function attributeLabels();
+
+    /**
+     * @inheritdoc
+     */
+    public function rules();
+
+}

--- a/src/models/SubmissionInterface.php
+++ b/src/models/SubmissionInterface.php
@@ -25,7 +25,7 @@ interface SubmissionInterface
      * 
      * @return Submission model
      */
-    public function populateModel(Request $request): Submission;
+    public function populateModel(Request $request);
 
     /**
      * Compiles the "From" name value from the submitted name.


### PR DESCRIPTION
Adding the extra configuration property `submissionModel` to `Settings.php` will allow devs to override the original submission model and creates more flexibility to change and customize the form fields in order to create more robust contact forms. Also adding the `SubmissionInterface` will maintain the required contract of the Submission model.

A use case for this (in my case) was the need of splitting the `fromName` field into `firstName` and `lastName` fields. Outside of this one use case, I am sure many devs would enjoy the ability to extend this contact form plugin submission model and customize their contact forms.