### PR TITLE
Prevent text garbling in message body

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -200,7 +200,7 @@ class Mailer extends Component
         }
 
         if ($body !== '') {
-            $body = preg_replace("/\r\n|\r/", "\n\n", $body);
+            $body = preg_replace('/\R/u', "\n\n", $body);
             $text .= "\n\n".$body;
         }
 

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -200,7 +200,7 @@ class Mailer extends Component
         }
 
         if ($body !== '') {
-            $body = preg_replace('/\R/', "\n\n", $body);
+            $body = preg_replace("/\r\n|\r/", "\n\n", $body);
             $text .= "\n\n".$body;
         }
 


### PR DESCRIPTION
preg_replace('/\R/', "\n\n", $body) cause text garbling in use of Japanese text（2.1% of General use Japanese characters）.
(e.g. "入","者"," 先"  → �)