### PR TITLE
Add error message to German translation

### DIFF
--- a/src/translations/de/contact-form.php
+++ b/src/translations/de/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Nachricht",
     'Subject' => "Betreff",
 
+    //error messages
+    'There was a problem with your submission, please check the form and try again!'
+    => 'Es gab ein Problem beim Abschicken des Formulars, bitte Eingaben prüfen und erneut versuchen!',
+
     //plugin settings
     "The email address(es) that the contact form will send to. Separate multiple email addresses with commas."
     => "Die Email-Adresse(n) an welche das Kontaktformular senden wird. Trennen Sie mehrere Email-Adressen mit Kommas.",


### PR DESCRIPTION
I’ve added a German translation for this error message:
```
There was a problem with your submission, please check the form and try again!
```