### PR TITLE
Added ability to translate the labels of the field keys in the generated content template.

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -191,7 +191,14 @@ class Mailer extends Component
         $text = '';
 
         foreach ($fields as $key => $value) {
-            $text .= ($text ? "\n" : '')."- **{$key}:** ";
+
+            $transKey = 'contact_form.' . lcfirst($key);
+            $transLabel = Craft::t('site', $transKey);
+            if ($transLabel === $transKey) {
+                $transLabel = $key;
+            }
+
+            $text .= ($text ? "\n" : '') . sprintf('- **%s:** ', $transLabel);
             if (is_array($value)) {
                 $text .= implode(', ', $value);
             } else {


### PR DESCRIPTION
Keys are prefixed with `contact_form.`, so you can define something like `contact_form.name` for the label in the `site.php` translations file.
Also a check, if the translation doesn't exist, it returns the generated-key, then it falls back to the original key (as it was before).