### PR TITLE
Fix original messages in translations

### DIFF
--- a/src/translations/ar/contact-form.php
+++ b/src/translations/ar/contact-form.php
@@ -13,19 +13,19 @@ return [
     => "عنوان (عناوين) البريد الإلكتروني التي سيرسل اليها نموذج الاتصال. يجب فصل عناوين البريد الإلكتروني المتعددة باستخدام الفواصل.",
     "Sender Text"
     => "نص المرسل",
-    "Text that will be prepended to the email's From Name to inform who the Contact Form actually was sent by."
+    "Text that will be prepended to the email’s From Name to inform who the Contact Form actually was sent by."
     => "النص الذي سيتم إلحاقه قبل اسم مرسل رسالة البريد الإلكتروني للإشارة إلى المرسل الفعلي لنموذج الاتصال.",
     "On behalf of"
     => "نيابة عن",
     "Subject Text"
     => "نص الموضوع",
-    "Text that will be prepended to the email's Subject to flag that it comes from the Contact Form."
+    "Text that will be prepended to the email’s Subject to flag that it comes from the Contact Form."
     => "النص الذي سيتم إلحاقه بموضوع البريد الإلكتروني للإشارة عن أنه أتي من نموذج الاتصال.",
     "Allow attachments?"
     => "السماح بالمرفقات؟",
     "Success Flash Message"
     => "رسالة النجاح",
-    "The flash message diplayed after successfully sending a message."
+    "The flash message displayed after successfully sending a message."
     => "رسالة الإخطار التي يتم عرضها بعد إرسال رسالة بنجاح.",
     "Your message has been sent."
     => "تم ارسال رسالتك."

--- a/src/translations/de/contact-form.php
+++ b/src/translations/de/contact-form.php
@@ -17,19 +17,19 @@ return [
     => "Die Email-Adresse(n) an welche das Kontaktformular senden wird. Trennen Sie mehrere Email-Adressen mit Kommas.",
     "Sender Text"
     => "Absendertext",
-    "Text that will be prepended to the email's From Name to inform who the Contact Form actually was sent by."
+    "Text that will be prepended to the email’s From Name to inform who the Contact Form actually was sent by."
     => "Text, welcher dem Absendernamen der Email vorangestellt wird, um aufzuzeigen von wem das Kontaktformular abgesendet wurde.",
     "On behalf of"
     => "Mitteilung von",
     "Subject Text"
     => "Betreffzeile",
-    "Text that will be prepended to the email's Subject to flag that it comes from the Contact Form."
+    "Text that will be prepended to the email’s Subject to flag that it comes from the Contact Form."
     => "Text, welcher der Betreffzeile vorangestellt wird, um aufzuzeigen dass die Mail vom Kontaktformular stammt",
     "Allow attachments?"
     => "Anlagen erlauben?",
     "Success Flash Message"
     => "Erfolgsnachricht",
-    "The flash message diplayed after successfully sending a message."
+    "The flash message displayed after successfully sending a message."
     => "Die Statusnachricht welche angezeigt wird, wenn eine Nachricht erfolgreich versendet wurde.",
     "Your message has been sent."
     => "Ihre Nachricht wurde versendet."

--- a/src/translations/nl/contact-form.php
+++ b/src/translations/nl/contact-form.php
@@ -13,19 +13,19 @@ return [
     => "Het e-mailadres of de e-mailadressen naar waar het contactformulier dient te verzenden. Scheid meerdere e-mailadressen met komma's.",
     "Sender Text"
     => "Afzendersbericht",
-    "Text that will be prepended to the email's From Name to inform who the Contact Form actually was sent by."
+    "Text that will be prepended to the email’s From Name to inform who the Contact Form actually was sent by."
     => "Tekst die wordt toegevoegd aan de naam van de verzender om te informeren door wie het contactformulier is verzonden.",
     "On behalf of"
     => "Namens",
     "Subject Text"
     => "Onderwerp tekst",
-    "Text that will be prepended to the email's Subject to flag that it comes from the Contact Form."
+    "Text that will be prepended to the email’s Subject to flag that it comes from the Contact Form."
     => "Tekst die zal worden toegevoegd aan het onderwerp om te tonen dat het afkomstig is van het contactformulier.",
     "Allow attachments?"
     => "Bijlagen toestaan?",
     "Success Flash Message"
     => "Statusbericht geslaagde verzending",
-    "The flash message diplayed after successfully sending a message."
+    "The flash message displayed after successfully sending a message."
     => "Het statusbericht dat wordt getoond na het succesvol versturen van een bericht.",
     "Your message has been sent."
     => "Jouw bericht is verstuurd."


### PR DESCRIPTION
It seems that the quotes changed in the english version for two messages.
There also was a typo fixed in the source, so translations needed an update.