### PR TITLE
Case-insensitive extension check for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes for Contact Form
 
-## Unreleased
+## 2.2.7 - 2020-05-04
+
+### Changed
+- Added case-insensitive extension check for attachments
 
 ## 2.2.6 - 2019-12-17
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "craftcms/contact-form",
   "description": "Add a simple contact form to your Craft CMS site",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "type": "craft-plugin",
   "keywords": [
     "cms",

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -83,7 +83,7 @@ class Mailer extends Component
                 // Validate that the file is safe to send by e-mail
                 $extension = pathinfo($attachment->name, PATHINFO_EXTENSION);
 
-                if (!in_array($extension, $allowedFileTypes)) {
+                if (!in_array(strtolower($extension), $allowedFileTypes)) {
                     $validAttachments = false;
                 }
 


### PR DESCRIPTION
Had a client that wanted to upload a .PDF file which failed because of this.