### PR TITLE
Include success flash message in JSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Release Notes for Contact Form
 
-## 2.2.8 - 2021-07-09
+## Unreleased
 
 ### Changed
-- Adds success flash message into JSON response
+- The success flash message is now returned in the response for AJAX calls.
 
 ## 2.2.7 - 2020-05-04
 
 ### Changed
-- Added case-insensitive extension check for attachments
+- Added case-insensitive extension check for attachments.
 
 ## 2.2.6 - 2019-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Contact Form
 
+## 2.2.8 - 2021-07-09
+
+### Changed
+- Adds success flash message into JSON response
+
 ## 2.2.7 - 2020-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ $('#my-form').submit(function(ev) {
         data: $(this).serialize(),
         success: function(response) {
             if (response.success) {
-                $('#thanks').fadeIn();
+                $('#thanks').text(response.message).fadeIn();
             } else {
                 // response.error will be an object containing any validation errors that occurred, indexed by field name
                 // e.g. response.error.fromName => ['From Name is required']

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -70,7 +70,7 @@ class SendController extends Controller
         }
 
         if ($request->getAcceptsJson()) {
-            return $this->asJson(['success' => true]);
+            return $this->asJson(['success' => true, 'message' => $settings->successFlashMessage]);
         }
 
         Craft::$app->getSession()->setNotice($settings->successFlashMessage);


### PR DESCRIPTION
If the mailer is successful, include `$settings->successFlashMessage` in the JSON response alongside `success => true` so front-end forms can display this message.

### Description



### Related issues

