### PR TITLE
Feature Add HTTP Status Codes on Validation failure.

### DIFF
--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -52,15 +52,15 @@ class SendController extends Controller
 
         if (!$plugin->getMailer()->send($submission)) {
             if ($request->getAcceptsJson()) {
-				/**
-				 * Set the HTTP Status Code
-				 */
-				$this->response->statusCode = $settings->validationFailStatusCode;
+                /**
+                 * Set the HTTP Status Code
+                 */
+                $this->response->statusCode = $settings->validationFailStatusCode;
 
-				/**
-				 * Return the JSON response.
-				 */
-				return $this->asJson(['errors' => $submission->getErrors()]);
+                /**
+                 * Return the JSON response.
+                 */
+                return $this->asJson(['errors' => $submission->getErrors()]);
             }
 
             Craft::$app->getSession()->setError(Craft::t('contact-form', 'There was a problem with your submission, please check the form and try again!'));

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -52,7 +52,15 @@ class SendController extends Controller
 
         if (!$plugin->getMailer()->send($submission)) {
             if ($request->getAcceptsJson()) {
-                return $this->asJson(['errors' => $submission->getErrors()]);
+				/**
+				 * Set the HTTP Status Code
+				 */
+				$this->response->statusCode = $settings->validationFailStatusCode;
+
+				/**
+				 * Return the JSON response.
+				 */
+				return $this->asJson(['errors' => $submission->getErrors()]);
             }
 
             Craft::$app->getSession()->setError(Craft::t('contact-form', 'There was a problem with your submission, please check the form and try again!'));

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -36,10 +36,10 @@ class Settings extends Model
      */
     public $successFlashMessage;
 
-	/**
-	 * @var int
-	 */
-	public $validationFailStatusCode = 200;
+    /**
+     * @var int
+     */
+    public $validationFailStatusCode = 200;
 
     /**
      * @inheritdoc

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -36,6 +36,11 @@ class Settings extends Model
      */
     public $successFlashMessage;
 
+	/**
+	 * @var int
+	 */
+	public $validationFailStatusCode = 200;
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
### Description
To be able to return a http error code when the validation fails, useful for dealing with the response on frontend. Retained status code 200 by default as to not break any existing functionality. Added setting as int so the user can decide if they want to throw 400 instead for example (I do so I can catch instead of searching a successful response for errors).
