### PR TITLE
Use Model::defineRules()

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,13 +273,33 @@ use yii\base\Event;
 Event::on(Submission::class, Submission::EVENT_AFTER_VALIDATE, function(Event $e) {
     /** @var Submission $submission */
     $submission = $e->sender;
-    
+
     // Make sure that `message[Phone]` was filled in
     if (empty($submission->message['Phone'])) {
         // Add the error
         // (This will be accessible via `message.getErrors('message.phone')` in the template.)
         $submission->addError('message.phone', 'A phone number is required.');
     }
+});
+```
+
+It's also possible to inject rules directly, via the inherited `Submission::EVENT_DEFINE_RULES` event:
+
+```php
+use craft\contactform\models\Submission;
+use craft\events\DefineRulesEvent;
+use yii\base\Event;
+
+// ...
+
+Event::on(Submission::class, Submission::EVENT_DEFINE_RULES, function(DefineRulesEvent $e) {
+    $e->rules[] = [['fromName'], 'required'];
+    $e->rules[] = [
+        ['subject'],
+        'in',
+        'range' => ['General', 'Booking', 'Catering'],
+        'message' => 'Please select one of the predefined options.',
+    ];
 });
 ```
 

--- a/src/models/Submission.php
+++ b/src/models/Submission.php
@@ -58,11 +58,13 @@ class Submission extends Model
     /**
      * @inheritdoc
      */
-    public function rules()
+    public function defineRules(): array
     {
-        return [
-            [['fromEmail', 'message'], 'required'],
-            [['fromEmail'], 'email']
-        ];
+        $rules = parent::defineRules();
+
+        $rules[] = [['fromEmail', 'message'], 'required'];
+        $rules[] = [['fromEmail'], 'email'];
+
+        return $rules;
     }
 }


### PR DESCRIPTION
Just noticed some custom rules weren't getting registered—turns out the `Submission` model clobbers the base `rules()` method, so the `EVENT_DEFINE_RULES` event is never triggered!