### PR TITLE
additional translations for the email body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Contact Form
 
+## Unreleased
+
+- Added translations for for `Email` and `Name`. ([#235](https://github.com/craftcms/contact-form/issues/235))
+
 ## 2.5.1 - 2022-05-02
 
 ### Fixed

--- a/src/translations/ar/contact-form.php
+++ b/src/translations/ar/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "الرسالة",
     'Subject' => "الموضوع",
 
+    // email body
+    'Email' => 'البريد',
+    'Name' => 'الاسم',
+
     // plugin settings
     "The email address(es) that the contact form will send to. Separate multiple email addresses with commas."
     => "عنوان (عناوين) البريد الإلكتروني التي سيرسل اليها نموذج الاتصال. يجب فصل عناوين البريد الإلكتروني المتعددة باستخدام الفواصل.",

--- a/src/translations/de/contact-form.php
+++ b/src/translations/de/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Nachricht",
     'Subject' => "Betreff",
 
+    // email body
+    'Email' => 'E-Mail',
+    'Name' => 'Name',
+
     // error messages
     'There was a problem with your submission, please check the form and try again!'
     => 'Es gab ein Problem beim Abschicken des Formulars, bitte Eingaben prüfen und erneut versuchen!',

--- a/src/translations/es/contact-form.php
+++ b/src/translations/es/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Mensaje",
     'Subject' => "Asunto",
 
+    // email body
+    'Email' => 'Correo electrónico',
+    'Name' => 'Nombre',
+
     //error messages
     'There was a problem with your submission, please check the form and try again!'
     => 'Hubo un problema con su envío, por favor revise el formulario y vuelva a intentarlo!',

--- a/src/translations/fr/contact-form.php
+++ b/src/translations/fr/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Message",
     'Subject' => "Sujet",
 
+    // email body
+    'Email' => 'E-mail',
+    'Name' => 'Nom',
+
     // error messages
     'There was a problem with your submission, please check the form and try again!'
     => 'Une erreur est survenue lors de la soumission, vérifiez le formulaire et essayez à nouveau !',

--- a/src/translations/it/contact-form.php
+++ b/src/translations/it/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Messaggio",
     'Subject' => "Oggetto",
 
+    // email body
+    'Email' => 'Email',
+    'Name' => 'Nome',
+
     //error messages
     'There was a problem with your submission, please check the form and try again!'
     => "Si è verificato un problema con l'invio, controlla il modulo e riprova!",

--- a/src/translations/nl/contact-form.php
+++ b/src/translations/nl/contact-form.php
@@ -8,6 +8,10 @@ return [
     'Message' => "Bericht",
     'Subject' => "Onderwerp",
 
+    // email body
+    'Email' => 'E-mail',
+    'Name' => 'Naam',
+
     // plugin settings
     "The email address(es) that the contact form will send to. Separate multiple email addresses with commas."
     => "Het e-mailadres of de e-mailadressen naar waar het contactformulier dient te verzenden. Scheid meerdere e-mailadressen met komma's.",


### PR DESCRIPTION
### Description
Added translations for `Email` and `Name` labels used in the email sent by this plugin. We had those exact translations for the CMS project, so it seemed like a quick win. 

It can be deployed to the `main` branch too.

### Related issues
#235 
