### PR TITLE
Bugfix/228 from name field safeguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added translations for for `Email` and `Name`. ([#235](https://github.com/craftcms/contact-form/issues/235))
+- Fixed an error that occurred if `fromName` was not specified on submissions. ([#228](https://github.com/craftcms/contact-form/issues/228))
 
 ## 3.0.0 - 2022-05-02
 

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -63,7 +63,7 @@ class Mailer extends Component
 
         $message = (new Message())
             ->setFrom([$fromEmail => $fromName])
-            ->setReplyTo([$fromEmail => (string)$submission->fromName])
+            ->setReplyTo([$submission->fromEmail => (string)$submission->fromName])
             ->setSubject($subject)
             ->setTextBody($textBody)
             ->setHtmlBody($htmlBody);

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -63,7 +63,7 @@ class Mailer extends Component
 
         $message = (new Message())
             ->setFrom([$fromEmail => $fromName])
-            ->setReplyTo([$submission->fromEmail => $submission->fromName])
+            ->setReplyTo([$fromEmail => (string)$submission->fromName])
             ->setSubject($subject)
             ->setTextBody($textBody)
             ->setHtmlBody($htmlBody);


### PR DESCRIPTION
### Description
In a Craft 4 version of this plugin, not specifying `fromName` causes an error to be thrown. This PR safeguards against it.


### Related issues
#228 
