### PR TITLE
Fix typo in 3.0.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 - 2023-03-16
 
-- Added translations for for `Email` and `Name`. ([#235](https://github.com/craftcms/contact-form/issues/235))
+- Added translations for `Email` and `Name`. ([#235](https://github.com/craftcms/contact-form/issues/235))
 - Fixed an error that occurred if `fromName` was not specified on submissions. ([#228](https://github.com/craftcms/contact-form/issues/228))
 
 ## 3.0.0 - 2022-05-02


### PR DESCRIPTION
### Description

Removes an excess "for" in the 3.0.1 release notes.

### Related issues

n/a