### PR TITLE
[v2] make single attachment forms validatable using the Yii file validator

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -70,7 +70,8 @@ class Mailer extends Component
         if ($submission->attachment !== null) {
             $allowedFileTypes = Craft::$app->getConfig()->getGeneral()->allowedFileExtensions;
 
-            foreach ($submission->attachment as $attachment) {
+            $attachments = is_array($submission->attachment) ? $submission->attachment : [$submission->attachment];
+            foreach ($attachments as $attachment) {
                 if (!$attachment) {
                     continue;
                 }

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -47,7 +47,7 @@ class SendController extends Controller
             if (is_array($_FILES['attachment']['name'])) {
                 $submission->attachment = UploadedFile::getInstancesByName('attachment');
             } else {
-                $submission->attachment = [UploadedFile::getInstanceByName('attachment')];
+                $submission->attachment = UploadedFile::getInstanceByName('attachment');
             }
         }
 


### PR DESCRIPTION
Fixes an issue with single file attachment validation, on the v2 branch.

Same changes as #255.

Same changes as 

# Related issues

Fixes https://github.com/craftcms/contact-form/issues/254
