### PR TITLE
single attachment file validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Contact Form
 
+## Unreleased
+
+- Fixed a bug where it wasn’t possible to upload a single file with the `attachment` param. ([#254](https://github.com/craftcms/contact-form/issues/254))
+
 ## 2.5.2 - 2023-03-16
 
 - Added translations for `Email` and `Name`. ([#235](https://github.com/craftcms/contact-form/issues/235))

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -70,6 +70,10 @@ class Mailer extends Component
         if ($submission->attachment !== null) {
             $allowedFileTypes = Craft::$app->getConfig()->getGeneral()->allowedFileExtensions;
 
+            if (!is_array($submission->attachment)) {
+                $submission->attachment = [$submission->attachment];
+            }
+
             foreach ($submission->attachment as $attachment) {
                 if (!$attachment) {
                     continue;

--- a/src/controllers/SendController.php
+++ b/src/controllers/SendController.php
@@ -47,7 +47,7 @@ class SendController extends Controller
             if (is_array($_FILES['attachment']['name'])) {
                 $submission->attachment = UploadedFile::getInstancesByName('attachment');
             } else {
-                $submission->attachment = [UploadedFile::getInstanceByName('attachment')];
+                $submission->attachment = UploadedFile::getInstanceByName('attachment');
             }
         }
 

--- a/src/models/Submission.php
+++ b/src/models/Submission.php
@@ -39,8 +39,8 @@ class Submission extends Model
     public $message;
 
     /**
-     * @var UploadedFile[]|null[]|null
-     * @phpstan-var array<UploadedFile|null>|null
+     * @var UploadedFile|UploadedFile[]|null[]|null
+     * @phpstan-var UploadedFile|array<UploadedFile|null>|null
      */
     public $attachment;
 


### PR DESCRIPTION
### Description
If a contact form has a single file attachment (`<input type="file" name="attachment">`), custom validation will only work if it’s an instance of `UploadedFile` and not an array of them.

When having a form that allows multiple file attachments (`<input type="file" name="attachment[]" multiple>`) and only uploading one file to it, custom validation will work, providing the validation rule contains the `maxFiles` parameter.

This can be merged into `v2` and `v3`.

I am closing #255 and #256 in favour of this one - thanks @nstCactus! 


### Related issues
#254 
